### PR TITLE
Deepen PublicLogic blueprint voice and palette

### DIFF
--- a/assets/publiclogic-logo.svg
+++ b/assets/publiclogic-logo.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 120" role="img" aria-labelledby="plTitle plDesc">
+  <title id="plTitle">PublicLogic Logo</title>
+  <desc id="plDesc">Stylized PublicLogic logomark with interlocking shield and circuit leaf.</desc>
+  <defs>
+    <linearGradient id="leaf" x1="0%" x2="100%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#8ad17c" />
+      <stop offset="100%" stop-color="#1f7043" />
+    </linearGradient>
+    <linearGradient id="shield" x1="0%" x2="100%" y1="0%" y2="0%">
+      <stop offset="0%" stop-color="#0f3c27" />
+      <stop offset="100%" stop-color="#2fa86b" />
+    </linearGradient>
+  </defs>
+  <rect width="320" height="120" rx="18" fill="#eff9f2" />
+  <g transform="translate(30 20)">
+    <path d="M48 0h24c26 0 48 22 48 48s-22 48-48 48H48z" fill="url(#shield)" />
+    <path d="M60 22c15-12 38-10 38 14 0 27-24 40-42 38 9-6 21-17 21-30 0-11-6-16-17-17z" fill="#ecf9f1" opacity="0.9" />
+    <path d="M20 12l28-12 28 12v32c0 22-12 40-28 52C32 84 20 66 20 44z" fill="#124f34" />
+    <path d="M48 28c-9 0-16 7-16 16 0 7 9 17 16 22 7-5 16-15 16-22 0-9-7-16-16-16zm0 24a8 8 0 118-8 8 8 0 01-8 8z" fill="url(#leaf)" />
+  </g>
+  <g transform="translate(150 42)" fill="#0f3c27">
+    <path d="M8 0h18c16 0 26 9 26 23S42 46 26 46H8zm18 36c7 0 12-4 12-13S33 10 26 10h-8v26z" />
+    <path d="M66 0h14v36h24v10H66z" />
+    <path d="M112 0h14v20l18-20h16l-18 20 20 26h-16l-12-16-8 8v8h-14z" />
+  </g>
+</svg>

--- a/municipal-blueprint.html
+++ b/municipal-blueprint.html
@@ -1,0 +1,994 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Polimorphic AI Municipal Platform – Sutton, MA Deployment Blueprint</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      color-scheme: light;
+      --accent: #0f3d2e;
+      --accent-dark: #0a271d;
+      --accent-light: #1f7a4d;
+      --accent-bright: #7ed957;
+      --accent-muted: #a0cfb0;
+      --background: #eff8f1;
+      --background-gradient: linear-gradient(180deg, rgba(11, 46, 32, 0.08), rgba(102, 187, 106, 0.1));
+      --text: #10241a;
+      --muted: #325744;
+      --surface: #ffffff;
+      --surface-tint: rgba(255, 255, 255, 0.86);
+      --border: #b7dec2;
+      --shadow: rgba(12, 54, 34, 0.18);
+      --shadow-strong: rgba(7, 32, 21, 0.28);
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: var(--background);
+      background-image: var(--background-gradient);
+      background-attachment: fixed;
+      color: var(--text);
+      line-height: 1.65;
+    }
+
+    header,
+    footer {
+      background: linear-gradient(135deg, rgba(10, 40, 27, 0.97), rgba(47, 168, 107, 0.88));
+      color: #f4fff7;
+      text-transform: uppercase;
+      letter-spacing: 0.18em;
+      font-weight: 600;
+      text-align: center;
+      padding: 0.75rem 1rem;
+      box-shadow: 0 14px 32px -18px var(--shadow-strong);
+      position: sticky;
+      top: 0;
+      z-index: 100;
+    }
+
+    header .header-inner {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 1rem;
+    }
+
+    header img {
+      height: 42px;
+      width: auto;
+      filter: drop-shadow(0 6px 12px rgba(16, 55, 34, 0.25));
+    }
+
+    header .header-text {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 0.15rem;
+    }
+
+    header .header-top {
+      font-size: 0.75rem;
+    }
+
+    header .header-sub {
+      font-size: 0.65rem;
+      letter-spacing: 0.32em;
+      opacity: 0.85;
+    }
+
+    footer {
+      position: static;
+      border-top: none;
+      box-shadow: 0 -12px 24px -20px var(--shadow-strong);
+    }
+
+    footer .footer-inner {
+      display: flex;
+      flex-direction: column;
+      gap: 0.35rem;
+      align-items: center;
+      letter-spacing: 0.18em;
+    }
+
+    .footer-top {
+      font-size: 0.78rem;
+    }
+
+    .footer-sub {
+      font-size: 0.68rem;
+      letter-spacing: 0.22em;
+      opacity: 0.85;
+    }
+
+    .container {
+      max-width: 1080px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem 4rem;
+    }
+
+    .cover {
+      background: linear-gradient(160deg, rgba(47, 168, 107, 0.18), rgba(9, 38, 25, 0.06)), var(--surface);
+      border: 1px solid rgba(47, 168, 107, 0.35);
+      padding: 3.5rem 3rem;
+      margin-bottom: 2.75rem;
+      border-radius: 18px;
+      box-shadow: 0 26px 52px -32px var(--shadow-strong);
+      overflow: hidden;
+    }
+
+    .cover-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 2.5rem;
+      align-items: center;
+    }
+
+    .cover-left {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .brandmark {
+      display: inline-flex;
+      align-items: center;
+      gap: 1rem;
+      padding: 0.85rem 1.2rem;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.78);
+      border: 1px solid rgba(47, 168, 107, 0.38);
+      box-shadow: 0 18px 36px -30px var(--shadow);
+      margin-bottom: 1.5rem;
+    }
+
+    .brandmark img {
+      height: 52px;
+      width: auto;
+    }
+
+    .brandmark-text {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+      text-transform: uppercase;
+      letter-spacing: 0.16em;
+      font-weight: 600;
+      color: var(--accent);
+      align-items: flex-start;
+    }
+
+    .brandmark-subtitle {
+      font-size: 0.7rem;
+      color: var(--muted);
+      letter-spacing: 0.24em;
+    }
+
+    .cover h1 {
+      font-size: clamp(2.6rem, 4vw, 3.6rem);
+      margin-bottom: 1.1rem;
+      color: var(--accent);
+      line-height: 1.15;
+    }
+
+    .cover p {
+      font-size: 1.05rem;
+      color: var(--muted);
+      margin: 0.35rem 0;
+      max-width: 620px;
+    }
+
+    .badge-group {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      margin-top: 1.5rem;
+    }
+
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      background: rgba(126, 217, 87, 0.16);
+      color: var(--accent);
+      padding: 0.55rem 1.1rem;
+      border-radius: 999px;
+      text-transform: uppercase;
+      font-size: 0.75rem;
+      letter-spacing: 0.18em;
+      font-weight: 650;
+      border: 1px solid rgba(15, 61, 46, 0.08);
+    }
+
+    .badge.highlight {
+      background: var(--accent);
+      color: #f4fff7;
+      box-shadow: 0 12px 24px -16px var(--shadow);
+    }
+
+    .cover-right {
+      display: grid;
+      gap: 1.5rem;
+    }
+
+    .value-pill {
+      background: rgba(255, 255, 255, 0.92);
+      border: 1px solid rgba(47, 168, 107, 0.32);
+      border-radius: 16px;
+      padding: 1.5rem;
+      box-shadow: 0 20px 40px -34px var(--shadow);
+    }
+
+    .value-pill h3 {
+      margin: 0 0 0.75rem;
+      color: var(--accent);
+      font-size: 1.15rem;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+    }
+
+    .value-pill p {
+      margin: 0;
+      color: var(--muted);
+      font-size: 0.95rem;
+    }
+
+    nav.toc {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 18px;
+      padding: 2rem;
+      margin-bottom: 3rem;
+      box-shadow: 0 28px 54px -40px var(--shadow);
+      backdrop-filter: blur(6px);
+    }
+
+    nav.toc h2 {
+      margin-top: 0;
+      color: var(--accent);
+    }
+
+    nav.toc ol {
+      margin: 0;
+      padding-left: 1.25rem;
+      columns: 2;
+      column-gap: 3rem;
+    }
+
+    nav.toc li {
+      margin-bottom: 0.75rem;
+      break-inside: avoid;
+    }
+
+    nav.toc a {
+      color: var(--accent-light);
+      text-decoration: none;
+      font-weight: 600;
+    }
+
+    section {
+      background: var(--surface-tint);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      padding: 2.75rem;
+      margin-bottom: 2.75rem;
+      box-shadow: 0 32px 62px -42px var(--shadow);
+      backdrop-filter: blur(8px);
+    }
+
+    section h2 {
+      margin-top: 0;
+      color: var(--accent);
+      font-size: clamp(1.8rem, 3vw, 2.2rem);
+      border-bottom: 2px solid rgba(27, 67, 50, 0.18);
+      padding-bottom: 0.75rem;
+      margin-bottom: 1.5rem;
+    }
+
+    h3 {
+      color: var(--accent);
+      margin-top: 2.25rem;
+      font-size: 1.3rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+
+    h4 {
+      color: var(--accent-light);
+      margin-top: 1.25rem;
+    }
+
+    p,
+    li {
+      font-size: 1rem;
+      color: var(--text);
+    }
+
+    ul,
+    ol {
+      padding-left: 1.25rem;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 1.5rem;
+    }
+
+    .card {
+      border: 1px solid rgba(47, 168, 107, 0.28);
+      border-radius: 16px;
+      padding: 1.4rem;
+      background: rgba(255, 255, 255, 0.9);
+      box-shadow: 0 22px 44px -36px var(--shadow);
+      transition: transform 0.3s ease, box-shadow 0.3s ease;
+    }
+
+    .card:hover {
+      transform: translateY(-4px);
+      box-shadow: 0 30px 68px -40px rgba(10, 61, 46, 0.28);
+    }
+
+    code,
+    pre {
+      font-family: 'Source Code Pro', Consolas, 'Courier New', monospace;
+      background: rgba(31, 122, 77, 0.12);
+      color: var(--accent);
+      border-radius: 10px;
+    }
+
+    pre {
+      padding: 1.25rem;
+      overflow-x: auto;
+      border: 1px solid rgba(27, 67, 50, 0.16);
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.5rem 0;
+      background: rgba(47, 168, 107, 0.09);
+    }
+
+    th,
+    td {
+      border: 1px solid rgba(27, 67, 50, 0.16);
+      padding: 0.85rem;
+      text-align: left;
+    }
+
+    th {
+      background: rgba(47, 168, 107, 0.22);
+      color: var(--accent);
+    }
+
+    .note {
+      padding: 1rem 1.25rem;
+      background: rgba(15, 61, 46, 0.08);
+      border-left: 4px solid var(--accent);
+      border-radius: 10px;
+      color: var(--text);
+      margin: 1.5rem 0;
+    }
+
+    @media (max-width: 768px) {
+      nav.toc ol {
+        columns: 1;
+      }
+
+      header {
+        letter-spacing: 0.12em;
+      }
+
+      header .header-inner {
+        flex-direction: column;
+        gap: 0.5rem;
+      }
+
+      header .header-text {
+        align-items: center;
+      }
+
+      header .header-sub {
+        letter-spacing: 0.2em;
+      }
+
+      .cover {
+        padding: 2.85rem 2rem;
+      }
+
+      .brandmark {
+        flex-direction: column;
+        align-items: flex-start;
+        text-align: left;
+      }
+
+      .brandmark-text {
+        align-items: flex-start;
+      }
+
+      .badge-group {
+        justify-content: flex-start;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="header-inner">
+      <img src="assets/publiclogic-logo.svg" alt="PublicLogic logo" />
+      <div class="header-text">
+        <span class="header-top">CONFIDENTIAL – PUBLICLOGIC</span>
+        <span class="header-sub">Practitioner-Led Municipal Innovation</span>
+      </div>
+    </div>
+  </header>
+  <div class="container">
+    <section class="cover">
+      <div class="cover-grid">
+        <div class="cover-left">
+          <div class="brandmark">
+            <img src="assets/publiclogic-logo.svg" alt="PublicLogic logo" />
+            <div class="brandmark-text">
+              <span>PublicLogic Blueprint</span>
+              <span class="brandmark-subtitle">VAULT™ + ARCHIEVE™ Deployment</span>
+            </div>
+          </div>
+          <h1>Polimorphic AI Municipal Platform Deployment Blueprint</h1>
+          <p>Town of Sutton, Massachusetts &mdash; Integrated with PublicLogic VAULT™ and ARCHIEVE™ frameworks.</p>
+          <p>Practitioner-authored master reference prepared for board and investor review. We position Sutton as the greenfield proving ground for the broader Polimorphic municipal ecosystem and make the value story unmissable.</p>
+          <div class="badge-group">
+            <span class="badge highlight">CONFIDENTIAL – PUBLICLOGIC</span>
+            <span class="badge">VAULT™ Retention Guarantee</span>
+            <span class="badge">ARCHIEVE™ Evidence Chain</span>
+          </div>
+        </div>
+        <div class="cover-right">
+          <div class="value-pill">
+            <h3>VAULT™ Value</h3>
+            <p>Automates statutory retention, enforces privacy-by-design, and injects evidentiary metadata at each municipal event trigger to keep boards audit-ready.</p>
+          </div>
+          <div class="value-pill">
+            <h3>PublicLogic Leadership</h3>
+            <p>Practitioner-led delivery keeps policy alignment, clerk adoption, and measurable civic outcomes moving in lockstep across Sutton’s departments.</p>
+          </div>
+          <div class="value-pill">
+            <h3>Investor Confidence</h3>
+            <p>Transparent KPIs, zero-trust security posture, and scalable microservice fabric demonstrate repeatability to adjacent municipalities and investors.</p>
+          </div>
+        </div>
+      </div>
+      <p class="note">VAULT™ and ARCHIEVE™ are trademarks of PublicLogic. All rights reserved. Distribution limited to authorized stakeholders under mutual non-disclosure agreement.</p>
+    </section>
+
+    <section>
+      <h2 id="executive-summary">Executive Summary</h2>
+      <p>We treat Sutton’s deployment as the baseline operating model for a compliance-first, resident-centric, and automation-enabled public services stack. The town becomes our repeatable case study, built to scale across the Commonwealth by pairing VAULT™ statutory retention enforcement with ARCHIEVE™ evidentiary-grade auditability.</p>
+      <div class="grid">
+        <div class="card">
+          <h3>Municipal Imperatives</h3>
+          <p>Sutton absorbs high service demand with a lean staff. We unify data, orchestrate casework, and protect frontline workflows while satisfying Massachusetts retention and transparency statutes.</p>
+        </div>
+        <div class="card">
+          <h3>VAULT™ + ARCHIEVE™ Advantage</h3>
+          <p>VAULT™ codifies retention schedules and privacy guardrails at the event level. ARCHIEVE™ seals the evidentiary chain so boards, auditors, and investors receive immutable proof of service delivery.</p>
+        </div>
+        <div class="card">
+          <h3>Practitioner-Led Trajectory</h3>
+          <p>PublicLogic stewards change management, clerk adoption, and KPIs. Year-one targets: 30% faster constituent response, 40% fewer compliance exceptions, and 15% operating cost savings.</p>
+        </div>
+      </div>
+    </section>
+
+    <nav class="toc" aria-label="Table of Contents">
+      <h2>Table of Contents</h2>
+      <ol>
+        <li><a href="#section1">Executive Technical Overview</a></li>
+        <li><a href="#section2">Foundational Architecture</a></li>
+        <li><a href="#section3">Technical Stack &amp; Microservices</a></li>
+        <li><a href="#section4">Module Implementations</a></li>
+        <li><a href="#section5">Compliance &amp; Security Architecture</a></li>
+        <li><a href="#section6">Integration Architecture</a></li>
+        <li><a href="#section7">AI and Automation Framework</a></li>
+        <li><a href="#section8">Infrastructure &amp; Deployment</a></li>
+        <li><a href="#section9">Implementation Methodology</a></li>
+        <li><a href="#section10">Success Metrics</a></li>
+        <li><a href="#section11">Appendices</a></li>
+      </ol>
+    </nav>
+
+    <section id="section1">
+      <h2>1. Executive Technical Overview</h2>
+      <h3>1.1 Municipal Problem Definition</h3>
+      <p>Sutton runs core services through legacy document stores, ad hoc spreadsheets, and siloed permitting tools. Massachusetts General Laws (MGL) Chapters 4, 40, and 66 impose rigorous retention and disclosure obligations that strain that patchwork. Fragmented workflows delay public records responses and block advanced analytics for capital planning, permitting, and civic engagement.</p>
+      <h3>1.2 Sutton as Proving Ground</h3>
+      <p>The town’s manageable population, collaborative leadership, and appetite for piloting modern technologies make Sutton our ideal proving ground. Regional partnerships with Worcester County agencies let us test interoperability against downstream state systems so we can replicate the deployment statewide.</p>
+      <h3>1.3 Living Document Philosophy</h3>
+      <p>This blueprint stays live. We synchronize implementation decisions, compliance evidence, and operational telemetry through Git-backed configuration as code. VAULT™ retention metadata and ARCHIEVE™ audit chains capture every policy shift or software upgrade with immutable provenance, and quarterly steering council reviews ratify updates and align budgets.</p>
+      <div class="note">VAULT™ and ARCHIEVE™ are trademarks of PublicLogic. All rights reserved.</div>
+    </section>
+
+    <section id="section2">
+      <h2>2. Foundational Architecture</h2>
+      <h3>2.1 System Philosophy</h3>
+      <ul>
+        <li><strong>Compliance-first logic:</strong> All business processes embed statutory rules and retention triggers at the event level.</li>
+        <li><strong>Event-driven orchestration:</strong> Kafka topics stream municipal events (permits, work orders, payments) to downstream services.</li>
+        <li><strong>Composable micro-frontends:</strong> Resident-facing portals consume GraphQL endpoints with role-aware personalization.</li>
+      </ul>
+      <h3>2.2 Event-Driven Design</h3>
+      <p>Events move through four domains—Civic Services, Finance, Infrastructure, and Records. Each domain publishes to a dedicated Kafka cluster under schema-registry governance. Event sourcing lets us replay activity for audits, training data, and scenario planning.</p>
+      <h3>2.3 Compliance-first Logic</h3>
+      <p>We codify business rules as policy-as-code modules deployed alongside every microservice. VAULT™ enforces retention policies, and ARCHIEVE™ provides immutable state machines that certify workflow completion, approvals, and data lineage.</p>
+      <h3>2.4 Reference Architecture Diagram</h3>
+      <p>Our reference diagrams show a layered architecture: user experience channels (web, mobile, clerk consoles), API gateway and integration adapters, service mesh, event backbone, data persistence tier, and compliance guardrails. We trace constituent interactions from portal through microservices, data lakes, and VAULT™/ARCHIEVE™ subsystems.</p>
+    </section>
+
+    <section id="section3">
+      <h2>3. Technical Stack &amp; Microservices</h2>
+      <div class="grid">
+        <div class="card">
+          <h3>Platform Layer</h3>
+          <ul>
+            <li>Kubernetes (AKS) with Calico network policies</li>
+            <li>HashiCorp Vault for secrets, integrated with VAULT™ retention signals</li>
+            <li>Istio service mesh with mutual TLS</li>
+          </ul>
+        </div>
+        <div class="card">
+          <h3>Event &amp; Data</h3>
+          <ul>
+            <li>Confluent Kafka with schema registry</li>
+            <li>Azure Synapse analytics lakehouse</li>
+            <li>Neo4j knowledge graph for compliance traceability</li>
+          </ul>
+        </div>
+        <div class="card">
+          <h3>AI &amp; Automation</h3>
+          <ul>
+            <li>Azure OpenAI for NLU, bounded by policy filters</li>
+            <li>Airflow DAGs for data processing pipelines</li>
+            <li>Feature store (Feast) for machine learning reuse</li>
+          </ul>
+        </div>
+      </div>
+      <h3>3.1 Microservices Catalog</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>Service</th>
+            <th>Responsibility</th>
+            <th>Key Interfaces</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Identity Broker</td>
+            <td>Federated identity with MA eAuthentication, OIDC, and clerk SSO</td>
+            <td>REST /oauth2/*, SCIM, LDAP proxy</td>
+          </tr>
+          <tr>
+            <td>Records Orchestrator</td>
+            <td>Applies VAULT™ retention tags to events, triggers ARCHIEVE™ notarization</td>
+            <td>gRPC retention.Apply, Kafka topic records.events</td>
+          </tr>
+          <tr>
+            <td>Permit Engine</td>
+            <td>Processes permit applications, inspections, and fee schedules</td>
+            <td>GraphQL civicPortal schema, REST /permits/v1</td>
+          </tr>
+          <tr>
+            <td>Service Desk</td>
+            <td>Omnichannel case management for SuttonFIX</td>
+            <td>Webhook intake, REST /cases, Kafka service.events</td>
+          </tr>
+          <tr>
+            <td>Financial Ledger Adapter</td>
+            <td>Synchronizes ERP data with Open Checkbook reporting</td>
+            <td>SFTP batches, REST /erp-sync, OData</td>
+          </tr>
+        </tbody>
+      </table>
+      <p>Each service ships with PublicLogic deployment playbooks, IaC templates, and retention mappings so Sutton’s technology and policy teams stay aligned sprint to sprint.</p>
+    </section>
+
+    <section id="section4">
+      <h2>4. Module Implementations</h2>
+      <h3>4.1 SuttonCLERK</h3>
+      <p>SuttonCLERK digitizes licensing, town meeting, and board administration workflows. Clerk consoles are RBAC-permissioned and capture evidentiary records for every agenda, motion, and vote.</p>
+      <h4>Data Schema (Excerpt)</h4>
+      <pre>{
+  "licenseId": "UUID",
+  "applicant": {
+    "name": "string",
+    "address": "string",
+    "contact": "string"
+  },
+  "boardReview": {
+    "meetingId": "UUID",
+    "agendaRef": "string",
+    "vote": {
+      "result": "APPROVED|DENIED|TABLED",
+      "timestamp": "ISO-8601",
+      "archieveHash": "string"
+    }
+  },
+  "retention": {
+    "policyId": "VAULT-RULE-2024-17",
+    "trigger": "issuanceDate",
+    "disposition": "7-years-active"
+  }
+}</pre>
+      <h4>API Flow</h4>
+      <ol>
+        <li>Applicant submits licensing form via civic portal (GraphQL mutation).</li>
+        <li>Permit Engine validates zoning overlays and fee schedules.</li>
+        <li>Records Orchestrator tags application with VAULT™ retention metadata.</li>
+        <li>ARCHIEVE™ notarizes board vote and timestamps final issuance.</li>
+        <li>ERP adapter posts financial transactions to Munis ERP.</li>
+      </ol>
+      <h3>4.2 SuttonFIX</h3>
+      <p>SuttonFIX delivers resident issue reporting with AI-assisted classification, field crew dispatch, and compliance-backed closure.</p>
+      <h4>AI Classification Sample</h4>
+      <pre><code class="language-python">from polymorphic_ai import TaskRouter, Guardrails
+
+router = TaskRouter("suttonfix", taxonomy={
+    "roadway": ["pothole", "signage", "storm-drain"],
+    "public-works": ["tree", "trash", "snow"],
+    "facilities": ["lighting", "park", "building"]
+})
+
+guards = Guardrails(policy="VAULT-RETENTION")
+
+issue = router.route(
+    text="There is a fallen tree blocking the entrance to Sutton Elementary",
+    metadata={"channel": "mobile", "geo": [-71.763, 42.150]}
+)
+
+guards.apply(issue, retention="90-days-active")
+print(issue.tag, issue.priority)
+</code></pre>
+      <h4>Service Workflow</h4>
+      <ul>
+        <li>Intake via web, mobile, voice (Twilio), or email ingestion.</li>
+        <li>NLU classification with fallback to clerk review for ambiguous cases.</li>
+        <li>Work order creation in Cartegraph with automated updates to residents.</li>
+        <li>Closure requires photographic evidence stored with ARCHIEVE™ hash for audit readiness.</li>
+      </ul>
+      <p>Together, SuttonCLERK and SuttonFIX show how we couple frontline service design with the VAULT™ and ARCHIEVE™ guardrails so municipal teams deliver faster while staying audit-ready.</p>
+    </section>
+
+    <section id="section5">
+      <h2>5. Compliance &amp; Security Architecture</h2>
+      <h3>5.1 VAULT™ State Machine</h3>
+      <p>VAULT™ enforces retention schedules with a deterministic state machine: <em>Ingestion → Classification → Hold → Active → Dormant → Disposition</em>. Every transition demands policy validation, legal hold checks, and supervisory approval, and each emits an event into the audit graph.</p>
+      <h3>5.2 ARCHIEVE™ Audit Chain</h3>
+      <p>ARCHIEVE™ captures every workflow milestone with chained hashes and Merkle proof exports. Evidence is notarized against Massachusetts-stamped time sources and anchored weekly to a permissioned blockchain shared among PublicLogic municipalities.</p>
+      <h3>5.3 Zero-Trust Controls</h3>
+      <ul>
+        <li>Continuous device posture assessment with Microsoft Defender.</li>
+        <li>Privileged access with just-in-time elevation and session recording.</li>
+        <li>Network segmentation enforced by Calico GlobalNetworkPolicies.</li>
+      </ul>
+      <h3>5.4 Compliance Benchmarks</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>Framework</th>
+            <th>Control Mapping</th>
+            <th>Evidence Source</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>MGL Chapter 66</td>
+            <td>Records retention workflow enforced via VAULT™</td>
+            <td>Retention state transitions, disposal certificates</td>
+          </tr>
+          <tr>
+            <td>NIST CSF</td>
+            <td>Identify &gt; Protect &gt; Detect &gt; Respond &gt; Recover mapped to microservices</td>
+            <td>Service mesh policies, SIEM dashboards</td>
+          </tr>
+          <tr>
+            <td>CJIS</td>
+            <td>Criminal justice integrations with encryption, audit tracking</td>
+            <td>ARCHIEVE™ evidence trails, IAM reports</td>
+          </tr>
+        </tbody>
+      </table>
+      <p>These controls keep Sutton’s leadership out in front of auditors and regulators while signaling to residents that the town safeguards data with discipline.</p>
+    </section>
+
+    <section id="section6">
+      <h2>6. Integration Architecture</h2>
+      <h3>6.1 ERP &amp; Financial Systems</h3>
+      <p>The financial ledger adapter synchronizes Munis transactions via secure REST and nightly SFTP batches. Payment events feed Kafka topics for automated reconciliation and drive the open checkbook portal without extra clerk effort.</p>
+      <h3>6.2 GIS &amp; Asset Systems</h3>
+      <p>ArcGIS integrations lean on Feature Services APIs and webhook notifications. SuttonFIX issues embed GIS parcel IDs so we can analyze public works interventions and capital planning by geography.</p>
+      <h3>6.3 State and Federal Systems</h3>
+      <ul>
+        <li><strong>MassGIS:</strong> Data overlays for zoning and emergency management.</li>
+        <li><strong>Department of Revenue (DOR):</strong> Secure file exchange for tax settlements.</li>
+        <li><strong>Commonwealth Virtual Gateway:</strong> Eligibility verification for human services referrals.</li>
+      </ul>
+      <h3>6.4 API Gateway &amp; GraphQL</h3>
+      <pre><code class="language-graphql">type Query {
+  permits(status: PermitStatus, board: String): [Permit]
+  retentionPolicies(service: String!): [RetentionPolicy]
+  workOrders(zone: String, priority: Priority): [WorkOrder]
+}
+
+type Mutation {
+  createIssue(input: IssueInput!): Issue
+  closeIssue(id: ID!, evidence: EvidenceInput!): Issue
+}
+</code></pre>
+      <p>Gateway enforcement covers schema contracts, rate limits, and VAULT™ retention tags surfaced through response headers. API adapters deliver canonical translation layers for legacy SOAP services.</p>
+      <p>These integration patterns let Sutton plug into Commonwealth systems without bending on PublicLogic’s compliance posture.</p>
+    </section>
+
+    <section id="section7">
+      <h2>7. AI and Automation Framework</h2>
+      <h3>7.1 Progressive AI Maturity Model</h3>
+      <ol>
+        <li><strong>Assistive:</strong> AI provides recommendations, humans approve actions, and every suggestion is logged.</li>
+        <li><strong>Augmented:</strong> AI performs low-risk tasks with automated retention tagging and human-on-the-loop monitoring.</li>
+        <li><strong>Bounded Autonomy:</strong> AI executes decisions with guardrails, escalations, and ARCHIEVE™ notarization so boards stay informed.</li>
+      </ol>
+      <h3>7.2 Pipeline Architecture</h3>
+      <ul>
+        <li>Data ingestion DAGs orchestrate ETL from ERP, GIS, and citizen apps.</li>
+        <li>Feature engineering pipelines produce embeddings for service classification.</li>
+        <li>Model monitoring dashboards track drift, fairness, and retention compliance.</li>
+      </ul>
+      <h3>7.3 Natural Language Understanding (NLU)</h3>
+      <p>Azure OpenAI models operate inside a private network with content filters trained on municipal vocabulary. Prompt templates embed policy citations, and responses redact sensitive fields according to VAULT™ access tiers.</p>
+      <h3>7.4 Bounded Autonomy Controls</h3>
+      <p>Decision policies incorporate multi-factor approvals, scenario simulators, and red-team testing. ARCHIEVE™ logs store rationale summaries for every autonomous action so board oversight stays rigorous.</p>
+      <p>The result is an automation program Sutton can scale without losing human accountability or compliance posture.</p>
+    </section>
+
+    <section id="section8">
+      <h2>8. Infrastructure &amp; Deployment</h2>
+      <h3>8.1 Reference Kubernetes YAML</h3>
+      <pre><code class="language-yaml">apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: suttonfix-service
+  labels:
+    app: suttonfix
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: suttonfix
+  template:
+    metadata:
+      labels:
+        app: suttonfix
+        retention.policy: "VAULT-RULE-2024-09"
+    spec:
+      serviceAccountName: suttonfix-sa
+      containers:
+        - name: suttonfix-api
+          image: registry.publiclogic.com/suttonfix:1.4.2
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "512Mi"
+            limits:
+              cpu: "1"
+              memory: "1Gi"
+          env:
+            - name: ARCHIEVE_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: archieve-secrets
+                  key: endpoint
+          volumeMounts:
+            - name: retention-policy
+              mountPath: /etc/policies
+      volumes:
+        - name: retention-policy
+          configMap:
+            name: vault-retention-suttonfix
+</code></pre>
+      <h3>8.2 Disaster Recovery</h3>
+      <p>Active-active clusters in Azure East US and Azure Gov MA keep recovery point objectives (RPO) under 15 minutes and recovery time objectives (RTO) under one hour. Daily immutable backups land in VAULT™ so retention rules stay intact even during incidents.</p>
+      <h3>8.3 Observability &amp; Monitoring</h3>
+      <ul>
+        <li>Prometheus metrics and Grafana dashboards with compliance overlays that highlight VAULT™ state changes.</li>
+        <li>Elastic SIEM for security event correlation tied to ARCHIEVE™ evidence IDs.</li>
+        <li>Synthetic monitoring of resident journeys and API health with alerts routed to practitioner response teams.</li>
+      </ul>
+      <p>This infrastructure stance keeps Sutton production-ready, observable, and aligned to PublicLogic’s practitioner playbooks.</p>
+    </section>
+
+    <section id="section9">
+      <h2>9. Implementation Methodology</h2>
+      <p>We drive the deployment through a disciplined practitioner cadence that keeps policy, technology, and community engagement moving together.</p>
+      <h3>9.1 Year-long Deployment Timeline</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>Quarter</th>
+            <th>Milestones</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Q1</td>
+            <td>Discovery, data inventory, compliance baseline, integration blueprint</td>
+          </tr>
+          <tr>
+            <td>Q2</td>
+            <td>Core microservices deployment, SuttonCLERK pilot, VAULT™ configuration</td>
+          </tr>
+          <tr>
+            <td>Q3</td>
+            <td>SuttonFIX launch, ERP adapters, AI model calibration, change management</td>
+          </tr>
+          <tr>
+            <td>Q4</td>
+            <td>Full production cutover, training completion, metrics validation, investor review</td>
+          </tr>
+        </tbody>
+      </table>
+      <h3>9.2 Change Management</h3>
+      <ul>
+        <li>Stakeholder council co-chaired by Town Administrator and CIO.</li>
+        <li>Communication plans with monthly newsletters and town hall demos.</li>
+        <li>Training academy with role-based curricula and VAULT™ compliance modules.</li>
+      </ul>
+      <h3>9.3 Governance RACI</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>Function</th>
+            <th>Responsible</th>
+            <th>Accountable</th>
+            <th>Consulted</th>
+            <th>Informed</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Platform Operations</td>
+            <td>Polimorphic DevOps</td>
+            <td>PublicLogic CTO</td>
+            <td>Sutton IT, Vendor SMEs</td>
+            <td>Town Administrator</td>
+          </tr>
+          <tr>
+            <td>Compliance Oversight</td>
+            <td>PublicLogic Compliance Office</td>
+            <td>Town Clerk</td>
+            <td>Legal Counsel</td>
+            <td>Select Board</td>
+          </tr>
+          <tr>
+            <td>AI Governance</td>
+            <td>Polimorphic AI Team</td>
+            <td>PublicLogic AI Ethics Officer</td>
+            <td>Sutton Advisory Committee</td>
+            <td>Residents</td>
+          </tr>
+        </tbody>
+      </table>
+      <p>Governance stays transparent: municipal leaders see progress, residents understand the benefits, and investors track milestones against the VAULT™/ARCHIEVE™ compliance ledger.</p>
+    </section>
+
+    <section id="section10">
+      <h2>10. Success Metrics</h2>
+      <h3>10.1 Operational Metrics</h3>
+      <ul>
+        <li>Average permit processing time reduced from 21 to 12 days.</li>
+        <li>SuttonFIX first-response time under 4 hours for priority issues.</li>
+        <li>99.95% platform uptime with zero unplanned outages over 30 minutes.</li>
+      </ul>
+      <h3>10.2 Compliance Metrics</h3>
+      <ul>
+        <li>100% retention alignment verified by VAULT™ reconciliation.</li>
+        <li>Audit findings resolved within 10 business days.</li>
+        <li>ARCHIEVE™ notarization coverage for all board actions.</li>
+      </ul>
+      <h3>10.3 Resident Satisfaction &amp; ROI</h3>
+      <ul>
+        <li>Net promoter score improvement of 12 points within year one.</li>
+        <li>Digital engagement adoption exceeding 65% of households.</li>
+        <li>Financial ROI achieved through $450K cumulative savings over three years.</li>
+      </ul>
+      <p>These metrics give Sutton’s leadership and investors a shared scoreboard that proves the municipal modernization thesis.</p>
+    </section>
+
+    <section id="section11">
+      <h2>11. Appendices</h2>
+      <h3>11.1 JSON Schemas</h3>
+      <pre>{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "RetentionPolicy",
+  "type": "object",
+  "properties": {
+    "policyId": { "type": "string" },
+    "service": { "type": "string" },
+    "trigger": { "type": "string" },
+    "duration": { "type": "string" },
+    "legalBasis": { "type": "string" }
+  },
+  "required": ["policyId", "service", "trigger", "duration"]
+}</pre>
+      <h3>11.2 Sample API Calls</h3>
+      <pre><code class="language-bash">curl -X POST https://api.publiclogic.com/suttonfix/issues \
+  -H "Authorization: Bearer &lt;token&gt;" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "summary": "Streetlight out near Town Hall",
+    "category": "facilities",
+    "channel": "web",
+    "retentionPolicy": "VAULT-RULE-2024-03"
+  }'
+</code></pre>
+      <h3>11.3 Retention Schedule (Excerpt)</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>Record Type</th>
+            <th>Policy</th>
+            <th>Duration</th>
+            <th>Disposition</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Town Meeting Minutes</td>
+            <td>VAULT-RULE-CLERK-01</td>
+            <td>Permanent</td>
+            <td>ARCHIEVE™ archival only</td>
+          </tr>
+          <tr>
+            <td>Permit Applications</td>
+            <td>VAULT-RULE-PERMIT-05</td>
+            <td>7 years</td>
+            <td>Secure destruction with certificate</td>
+          </tr>
+          <tr>
+            <td>Service Desk Tickets</td>
+            <td>VAULT-RULE-SERVICE-02</td>
+            <td>3 years</td>
+            <td>Automated purge post-hold clearance</td>
+          </tr>
+        </tbody>
+      </table>
+      <h3>11.4 Compliance Crosswalk</h3>
+      <ul>
+        <li>HIPAA interfaces: segregated data plane, encryption at rest, DLP scanning.</li>
+        <li>ADA accessibility: WCAG 2.1 AA compliance for resident portals.</li>
+        <li>Records law alignment: integrated legal hold management.</li>
+      </ul>
+      <h3>11.5 Glossary</h3>
+      <ul>
+        <li><strong>ARCHIEVE™:</strong> PublicLogic’s evidentiary audit framework for municipal workflows.</li>
+        <li><strong>VAULT™:</strong> Retention orchestration engine that enforces statutory schedules.</li>
+        <li><strong>Bounded Autonomy:</strong> AI pattern where machine decisions remain within policy-defined constraints and oversight triggers.</li>
+        <li><strong>Event Sourcing:</strong> Architectural style capturing state changes as a sequence of immutable events.</li>
+      </ul>
+      <p>These appendices equip Sutton teams with the artefacts needed to implement, govern, and scale the platform on their own terms.</p>
+    </section>
+  </div>
+  <footer>
+    <div class="footer-inner">
+      <span class="footer-top">CONFIDENTIAL – PUBLICLOGIC</span>
+      <span class="footer-sub">VAULT™ and ARCHIEVE™ are trademarks of PublicLogic. All rights reserved.</span>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- refresh the municipal blueprint theme with a deeper PublicLogic green gradient, hover states, and glassmorphic section styling
- sharpen executive summary and section narratives to match the requested practitioner-led tone across compliance, integration, AI, and governance content
- add closing statements that reinforce VAULT™/ARCHIEVE™ value and provide clear investor- and board-facing framing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d688cb49bc83258da35d6f90eee2be